### PR TITLE
Quick fix for websockets 14.1

### DIFF
--- a/ooresults/websocket_server/websocket_server.py
+++ b/ooresults/websocket_server/websocket_server.py
@@ -65,7 +65,7 @@ class WebSocketServer(threading.Thread):
         self.handler = WebSocketHandler(
             demo_reader=self.demo_reader, import_stream=self.import_stream
         )
-        start_server = websockets.serve(
+        start_server = websockets.legacy.server.serve(
             self.handler.handler, self.host, self.port, loop=self.loop, ssl=ssl_context
         )
         self.loop.run_until_complete(start_server)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "clevercsv",
     "jsonschema",
     "websocket-client",
-    "websockets >= 13.0.1",
+    "websockets >= 14.1",
     "fpdf2 != 2.5.7",
     "pyserial",
     "tzlocal",

--- a/tests/websocket/test_import_handler.py
+++ b/tests/websocket/test_import_handler.py
@@ -120,7 +120,7 @@ class WebSocketServer(threading.Thread):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop=self.loop)
         self.server = self.loop.run_until_complete(
-            websockets.serve(
+            websockets.legacy.server.serve(
                 ws_handler=self.handler.handler,
                 host=self.host,
                 port=self.port,
@@ -161,7 +161,7 @@ async def test_live_server_event_key_not_found(
   </Event>
 </ResultList>
 """
-    async with websockets.connect(
+    async with websockets.legacy.client.connect(
         uri="ws://localhost:8081/import",
         extra_headers={"X-Event-Key": "xxx"},
     ) as client:
@@ -192,7 +192,7 @@ async def test_live_server_event_key_found_but_parse_error_in_result_list(
   </Event>
 </ResultList>
 """
-    async with websockets.connect(
+    async with websockets.legacy.client.connect(
         uri="ws://localhost:8081/import",
         extra_headers={"X-Event-Key": "local"},
     ) as client:
@@ -224,7 +224,7 @@ async def test_live_server_event_key_found(
   </Event>
 </ResultList>
 """
-    async with websockets.connect(
+    async with websockets.legacy.client.connect(
         uri="ws://localhost:8081/import",
         extra_headers={"X-Event-Key": "local"},
     ) as client:
@@ -277,7 +277,7 @@ async def test_live_server_import_result_list_snapshot(
     s = datetime.datetime(2020, 2, 9, 10, 0, 0, tzinfo=timezone(timedelta(hours=1)))
     f = datetime.datetime(2020, 2, 9, 10, 33, 21, tzinfo=timezone(timedelta(hours=1)))
 
-    async with websockets.connect(
+    async with websockets.legacy.client.connect(
         uri="ws://localhost:8081/import",
         extra_headers={"X-Event-Key": "local"},
     ) as client:
@@ -400,7 +400,7 @@ async def test_live_server_import_result_list_delta(
     s = datetime.datetime(2020, 2, 9, 10, 0, 0, tzinfo=timezone(timedelta(hours=1)))
     f = datetime.datetime(2020, 2, 9, 10, 33, 21, tzinfo=timezone(timedelta(hours=1)))
 
-    async with websockets.connect(
+    async with websockets.legacy.client.connect(
         uri="ws://localhost:8081/import",
         extra_headers={"X-Event-Key": "local"},
     ) as client:

--- a/tests/websocket/test_websocket_handler.py
+++ b/tests/websocket/test_websocket_handler.py
@@ -83,7 +83,7 @@ class WebSocketServer(threading.Thread):
         self.streaming = Streaming(loop=self.loop)
 
         self.server = self.loop.run_until_complete(
-            websockets.serve(
+            websockets.legacy.server.serve(
                 ws_handler=self.handler.handler,
                 host=self.host,
                 port=self.port,
@@ -116,7 +116,7 @@ async def test_no_access_if_event_not_found(
     event_id: int,
     websocket_server: WebSocketServer,
 ):
-    async with websockets.connect(uri="ws://localhost:8081/si1") as si1_client:
+    async with websockets.legacy.client.connect(uri="ws://localhost:8081/si1") as si1_client:
         await si1_client.send("xxx,local")
         response = await si1_client.recv()
         assert response == "__no_access__"
@@ -131,7 +131,7 @@ async def test_no_access_if_key_not_found(
     event_id: int,
     websocket_server: WebSocketServer,
 ):
-    async with websockets.connect("ws://localhost:8081/si1") as si1_client:
+    async with websockets.legacy.client.connect("ws://localhost:8081/si1") as si1_client:
         await si1_client.send(f"{event_id},xxx")
         response = await si1_client.recv()
         assert response == "__no_access__"
@@ -146,7 +146,7 @@ async def test_reader_status_received_if_event_and_key_found(
     event_id: int,
     websocket_server: WebSocketServer,
 ):
-    async with websockets.connect(uri="ws://localhost:8081/si1") as si1_client:
+    async with websockets.legacy.client.connect(uri="ws://localhost:8081/si1") as si1_client:
         await si1_client.send(f"{event_id},local")
         response = await si1_client.recv()
         assert json.loads(response) == {"status": "readerOffline", "data": ""}
@@ -158,7 +158,7 @@ async def test_cardreader_event_key_not_found(
     event_id: int,
     websocket_server: WebSocketServer,
 ):
-    async with websockets.connect(
+    async with websockets.legacy.client.connect(
         uri="ws://localhost:8081/cardreader",
         extra_headers={"X-Event-Key": "xxx"},
     ) as reader:
@@ -181,12 +181,12 @@ async def test_cardreader_event_key_found_and_reader_disconnected(
     event_id: int,
     websocket_server: WebSocketServer,
 ):
-    async with websockets.connect(uri="ws://localhost:8081/si1") as si1_client:
+    async with websockets.legacy.client.connect(uri="ws://localhost:8081/si1") as si1_client:
         await si1_client.send(f"{event_id},local")
         response = await si1_client.recv()
         assert json.loads(response) == {"status": "readerOffline", "data": ""}
 
-        async with websockets.connect(
+        async with websockets.legacy.client.connect(
             uri="ws://localhost:8081/cardreader",
             extra_headers={"X-Event-Key": "local"},
         ) as reader:
@@ -220,7 +220,7 @@ async def reader(
     event_id: int,
     websocket_server: WebSocketServer,
 ):
-    client = await websockets.connect(
+    client = await websockets.legacy.client.connect(
         uri="ws://localhost:8081/cardreader",
         extra_headers={"X-Event-Key": "local"},
     )
@@ -246,7 +246,7 @@ async def si1_clients(
     reader: websockets.WebSocketClientProtocol,
     websocket_server: WebSocketServer,
 ):
-    connect = websockets.connect(uri="ws://localhost:8081/si1")
+    connect = websockets.legacy.client.connect(uri="ws://localhost:8081/si1")
     async with connect as c1, connect as c2, connect as c3, connect as c4:
         si1_clients = [c1, c2, c3, c4]
         for c in si1_clients:


### PR DESCRIPTION
Old asyncio api is deprecated. When updating packages, websockets 14.1 is breaking the websocket server.

All calls to websockets.connect/serve changed to websockets.legacy.client.connect/serve
Deeper modifications are needed to use the new asyncio api.

All tests are passing successfully with python 3.11.9